### PR TITLE
Add caller level control

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -58,15 +58,24 @@ type logData struct {
 	Trace     []string               `json:"trace,omitempty"`
 }
 
+// SetCallerLevel will adjust the relative caller level in log output.
+func SetCallerLevel(level uint) {
+	callerLevel = level
+}
+
+var callerLevel uint
+
 func getCaller() string {
 	caller := ""
 	a := 0
 	for {
-		if pc, file, line, ok := runtime.Caller(a); ok {
+		if _, file, _, ok := runtime.Caller(a); ok {
 			if !strings.Contains(strings.ToLower(file), "github.com/bdlm/log") ||
 				strings.HasSuffix(strings.ToLower(file), "_test.go") {
-				caller = fmt.Sprintf("%s:%d %s", path.Base(file), line, runtime.FuncForPC(pc).Name())
-				break
+				if pc, file, line, ok := runtime.Caller(a + int(callerLevel)); ok {
+					caller = fmt.Sprintf("%s:%d %s", path.Base(file), line, runtime.FuncForPC(pc).Name())
+					break
+				}
 			}
 		} else {
 			break

--- a/formatter.go
+++ b/formatter.go
@@ -69,13 +69,17 @@ func getCaller() string {
 	caller := ""
 	a := 0
 	for {
-		if _, file, _, ok := runtime.Caller(a); ok {
+		if pc, file, line, ok := runtime.Caller(a); ok {
 			if !strings.Contains(strings.ToLower(file), "github.com/bdlm/log") ||
 				strings.HasSuffix(strings.ToLower(file), "_test.go") {
-				if pc, file, line, ok := runtime.Caller(a + int(callerLevel)); ok {
-					caller = fmt.Sprintf("%s:%d %s", path.Base(file), line, runtime.FuncForPC(pc).Name())
-					break
+				if 0 != callerLevel {
+					if pc, file, line, ok := runtime.Caller(a - int(callerLevel)); ok {
+						caller = fmt.Sprintf("%s:%d %s", path.Base(file), line, runtime.FuncForPC(pc).Name())
+						break
+					}
 				}
+				caller = fmt.Sprintf("%s:%d %s", path.Base(file), line, runtime.FuncForPC(pc).Name())
+				break
 			}
 		} else {
 			break

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,24 @@
+package log
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSetCallerLevel(t *testing.T) {
+	formatter := &JSONFormatter{}
+	entry := WithField("error", errors.New("wild walrus"))
+
+	data := getData(entry, formatter.FieldMap, formatter.EscapeHTML)
+	if !strings.Contains(data.Caller, "formatter_test.go:13") {
+		t.Fatal("invalid caller: ", data.Caller)
+	}
+
+	SetCallerLevel(1)
+	data = getData(entry, formatter.FieldMap, formatter.EscapeHTML)
+	if strings.Contains(data.Caller, "formatter_test.go:13") {
+		t.Fatal("invalid caller: ", data.Caller)
+	}
+	SetCallerLevel(0)
+}


### PR DESCRIPTION
#### Please describe this change
<!--
In particular, your use case, any related issues, any questions you may have, functionality you are unsure is correct, etc.
-->

Add an exported method for setting the call stack position relative to the resulting line used for caller output. Useful for wrapper functions that have log output. `SetCallerLevel(level int)`

#### Changes
What types of changes does your code introduce?
<!--
Put an `[x]` in all the boxes that apply.
-->
* [x] Feature development


#### Checklist
<!--
Put an `[x]` in all the boxes that apply.
-->
* [x] Unit tests, acceptance tests, lint checks, code style checks, etc., all pass
