### PR TITLE
Use os.Hostname in addition to Getenv("HOSTNAME")

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -242,6 +242,13 @@ func getData(entry *Entry, fieldMap FieldMap, escapeHTML, isTTY bool) *logData {
 		Trace:     getTrace(),
 	}
 
+	if data.Hostname == "" {
+		hostname, err := os.Hostname()
+		if err == nil {
+			data.Hostname = hostname
+		}
+	}
+
 	data.LabelCaller = fieldMap.resolve(LabelCaller)
 	data.LabelData = fieldMap.resolve(LabelData)
 	data.LabelError = fieldMap.resolve(LabelError)

--- a/text_formatter_test.go
+++ b/text_formatter_test.go
@@ -81,7 +81,7 @@ func TestEscaping_Interface(t *testing.T) {
 
 func TestEscaping_Error(t *testing.T) {
 	defer newStd()
-	tf := &TextFormatter{DisableTTY: true}
+	tf := &TextFormatter{DisableTTY: true, DisableHostname: true}
 
 	testCases := []struct {
 		value    interface{}


### PR DESCRIPTION
#### Please describe this change
The environment variable `HOSTNAME` is used as the sole source of the hostname in formatter.go.

This consults `os.Hostname()` as well, in case `HOSTNAME` is empty. This is the case on a machine I used.

See #28.

#### Changes
What types of changes does your code introduce?
<!--
Put an `[x]` in all the boxes that apply.
-->
* [x] Bugfix
* [x] Feature development
* [ ] Tech Debt (fixes an infrastructure issue, code quality issue, etc.)
* [ ] Other (please explain here)


#### Checklist
<!--
Put an `[x]` in all the boxes that apply.
-->
* [x] Unit tests, acceptance tests, lint checks, code style checks, etc., all pass

I have not added tests, as wrapping this particular change would be difficult in just Go.

However, a test has been fixed.

#### Any relevant logs, error output, etc?

n/a

#### Any other comments?

n/a
